### PR TITLE
Fixes to make ekg-core compile against GHC 7.10.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 cabal.config
 cabal.sandbox.config
 examples/Group
+*.sublime-*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,35 +1,41 @@
-# NB: don't set `language: haskell` here
-
 # The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
 env:
- - GHCVER=7.4.2
- - GHCVER=7.6.3
- - GHCVER=7.8.2
-# - GHCVER=head  # see section about GHC HEAD snapshots
+ - CABALVER=1.18 GHCVER=7.6.3
+ - CABALVER=1.18 GHCVER=7.8.3
+ - CABALVER=1.22 GHCVER=7.10.1
+ - CABALVER=head GHCVER=head   # see section about GHC HEAD snapshots
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
- - sudo add-apt-repository -y ppa:hvr/ghc
- - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
- - export PATH=/opt/ghc/$GHCVER/bin:$PATH
+ - travis_retry sudo add-apt-repository -y ppa:hvr/ghc
+ - travis_retry sudo apt-get update
+ - travis_retry sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER # see note about happy/alex
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 install:
- - cabal-1.18 update
- - cabal-1.18 install --only-dependencies --enable-tests --enable-benchmarks
+ - cabal --version
+ - echo "$(ghc --version) [$(ghc --print-project-git-commit-id 2> /dev/null || echo '?')]"
+ - travis_retry cabal update
+ - cabal install --only-dependencies --enable-tests --enable-benchmarks
+
+matrix:
+  allow_failures:
+   - env: CABALVER=head GHCVER=head
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- - cabal-1.18 configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
- - cabal-1.18 build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal-1.18 check
- - cabal-1.18 sdist   # tests that a source-distribution can be generated
+ - if [ -f configure.ac ]; then autoreconf -i; fi
+ - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal-1.18 info . | awk '{print $2 ".tar.gz";exit}') ;
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
    cd dist/;
    if [ -f "$SRC_TGZ" ]; then
-      cabal-1.18 install "$SRC_TGZ";
+      cabal install --force-reinstalls "$SRC_TGZ";
    else
       echo "expected '$SRC_TGZ' not found";
       exit 1;

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -28,7 +28,7 @@ library
     System.Metrics.ThreadId
 
   build-depends:
-    ghc-prim < 0.4,
+    ghc-prim < 0.5,
     base >= 4.5 && < 4.9,
     containers >= 0.5 && < 0.6,
     text < 1.3,


### PR DESCRIPTION
All I've really done is bump a few upper bounds on dependencies so that it compiles.

Probably the biggest change is that I used the mutli-ghc-travis project as a template for a Travis config, which helped me to test the varying versions of GHC, feel free to fire that into the sun if you so wish.