### PR TITLE
Added simple name spaces to ekg-core registerGcMetrics.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ cabal.config
 cabal.sandbox.config
 examples/Group
 *.sublime-*
-/TAGS
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal.config
 cabal.sandbox.config
 examples/Group
 *.sublime-*
+/TAGS

--- a/System/Metrics.hs
+++ b/System/Metrics.hs
@@ -1,8 +1,8 @@
-{-# LANGUAGE BangPatterns              #-}
-{-# LANGUAGE CPP                       #-}
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE OverloadedStrings         #-}
-{-# LANGUAGE RecordWildCards           #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 -- | A module for defining metrics that can be monitored.
 --
 -- Metrics are used to monitor program behavior and performance. All
@@ -414,9 +414,9 @@ registerGcMetrics :: Store -> IO ()
 registerGcMetrics  = registerNamedGcMetrics ""
 
 
--- | same as registerGcMetrics but you can append a namespace
+-- | Same as 'registerGcMetrics' but you can append a namespace
 -- >>> registerNamedGcMetrics "myapp" store
--- produces: 'myapp.rts.gc.xxx' for all Store entriesbc
+-- Produces: 'myapp.rts.gc.xxx' for all Store entriesbc
 registerNamedGcMetrics :: T.Text -> Store -> IO ()
 registerNamedGcMetrics namespace store =
     registerGroup

--- a/System/Metrics.hs
+++ b/System/Metrics.hs
@@ -416,7 +416,7 @@ registerGcMetrics  = registerNamedGcMetrics ""
 
 -- | same as registerGcMetrics but you can append a namespace
 -- >>> registerNamedGcMetrics "myapp" store
--- produces: 'myapp.rts.gc.xxx' for all Store entries
+-- produces: 'myapp.rts.gc.xxx' for all Store entriesbc
 registerNamedGcMetrics :: T.Text -> Store -> IO ()
 registerNamedGcMetrics namespace store =
     registerGroup

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,5 +1,5 @@
 name:                ekg-core
-version:             0.1.1.7569
+version:             0.1.2.0
 synopsis:            Tracking of system metrics
 description:
   This library lets you defined and track system metrics.

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,5 +1,5 @@
 name:                ekg-core
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            Tracking of system metrics
 description:
   This library lets you defined and track system metrics.

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,5 +1,5 @@
 name:                ekg-core
-version:             0.1.1.1
+version:             0.1.1.7569
 synopsis:            Tracking of system metrics
 description:
   This library lets you defined and track system metrics.


### PR DESCRIPTION
Just a small change so you can write:
``` haskell
registerNamedGcMetrics "myapp" store
-- produces: 'myapp.rts.gc.xxx' for all Store entries
```
