### PR TITLE
Implement tagged metrics

### DIFF
--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -33,6 +33,7 @@ library
     ghc-prim < 0.6,
     base >= 4.5 && < 4.11,
     containers >= 0.5 && < 0.6,
+    hashable >= 1.2 && < 1.3,
     text < 1.3,
     unordered-containers < 0.3
 

--- a/ekg-core.cabal
+++ b/ekg-core.cabal
@@ -1,5 +1,5 @@
 name:                ekg-core
-version:             0.1.1.1
+version:             0.2.1.0
 synopsis:            Tracking of system metrics
 description:
   This library lets you defined and track system metrics.


### PR DESCRIPTION
This is an experiment to address #6 and could help for #12 .
This change uses a non-empty list of tags instead of single tag name for metrics.

The main design choice to figure out is whether tags should be key/values or values only. In this experiment I use values only.

Pros:
- most simple API change to augment metric names, exposing only a low-overhead API
- one can add different flavors of typeful APIs on top of this change
- one can add semantics for key-values by adding some parsing rule in the tags (cf. example in upcoming change requests)
- one is not bound to key/value semantics if set-of-labels is what a user wants

Cons:
- does not store tag names, so more bookeeping is needed
- may lead to diverging rules for formatting key-values in tags (I guess most people will keep it simple)
- does not address the need to create new tags dynamically (with indsight, I guess it's good to expose an API which makes it harder to create unbounded amount of tags)