### PR TITLE
Fix space leak in System.Metrics.Label.set

### DIFF
--- a/System/Metrics/Label.hs
+++ b/System/Metrics/Label.hs
@@ -12,7 +12,7 @@ module System.Metrics.Label
     , modify
     ) where
 
-import Data.IORef (IORef, atomicModifyIORef, atomicWriteIORef, newIORef, readIORef)
+import Data.IORef (IORef, atomicModifyIORef', atomicWriteIORef, newIORef, readIORef)
 import qualified Data.Text as T
 import Prelude hiding (read)
 
@@ -34,6 +34,4 @@ set (C ref) !i = atomicWriteIORef ref i
 -- | Set the label to the result of applying the given function to the
 -- value.
 modify :: (T.Text -> T.Text) -> Label -> IO ()
-modify f (C ref) = do
-    !_ <- atomicModifyIORef ref $ \ i -> let i' = f i in (i', i')
-    return ()
+modify f (C ref) = atomicModifyIORef' ref $ \i -> (f i, ())

--- a/System/Metrics/Label.hs
+++ b/System/Metrics/Label.hs
@@ -12,7 +12,7 @@ module System.Metrics.Label
     , modify
     ) where
 
-import Data.IORef (IORef, atomicModifyIORef, newIORef, readIORef)
+import Data.IORef (IORef, atomicModifyIORef, atomicWriteIORef, newIORef, readIORef)
 import qualified Data.Text as T
 import Prelude hiding (read)
 
@@ -29,7 +29,7 @@ read = readIORef . unC
 
 -- | Set the label to the given value.
 set :: Label -> T.Text -> IO ()
-set (C ref) !i = atomicModifyIORef ref $ \ _ -> (i, ())
+set (C ref) !i = atomicWriteIORef ref i
 
 -- | Set the label to the result of applying the given function to the
 -- value.


### PR DESCRIPTION
`atomicModifyIORef` leaks space because function is applied lazily to the value stored (see https://hackage.haskell.org/package/base-4.10.0.0/docs/Data-IORef.html#v:atomicModifyIORef).

The other commit just makes the definition of `modify` a bit cleaner.