### PR TITLE
Fix distribution min/max

### DIFF
--- a/System/Metrics/Distribution.hsc
+++ b/System/Metrics/Distribution.hsc
@@ -91,13 +91,14 @@ instance Storable CDistrib where
 newCDistrib :: IO (ForeignPtr CDistrib)
 newCDistrib = do
     fp <- mallocForeignPtr
+    let infinity = 1/0
     withForeignPtr fp $ \ p -> poke p $ CDistrib
         { cCount      = 0
         , cMean       = 0.0
         , cSumSqDelta = 0.0
         , cSum        = 0.0
-        , cMin        = 0.0
-        , cMax        = 0.0
+        , cMin        = infinity
+        , cMax        = -infinity
         , cLock       = 0
         }
     return fp

--- a/cbits/distrib.c
+++ b/cbits/distrib.c
@@ -38,7 +38,7 @@ void hs_distrib_combine(struct distrib* b, struct distrib* a) {
   a->mean = (count == 0) ? 0.0 : mean; // divide-by-zero gives NaN
   a->sum_sq_delta = sum_sq_delta;
   a->sum = a->sum + b->sum;
-  a->min = b->min; // This is slightly hacky, but ok: see
-  a->max = b->max; // 813aa426be78e8abcf1c7cdd43433bcffa07828e
+  a->min = b->min < a->min ? b->min : a->min;
+  a->max = b->max > a->max ? b->max : a->max;
   hs_unlock(&b->lock);
 }


### PR DESCRIPTION
Previously the min/max returned by `read :: Distribution -> IO Stats` would always be equal to the values recorded in the last stripe, due to an incorrect bugfix (see commit 813aa426be78e8abcf1c7cdd43433bcffa07828e). We can fix the original bug (as well as the current incarnation) by properly initialising new distributions with the unit elements of the corresponding monoids (`inf` for `min` and `-inf` for `max`).

For context: the `max` of a distribution we added to our program was always returning `0` before this fix:

The _max_ of the distribution previously:
![image](https://user-images.githubusercontent.com/757280/136576343-b65b7293-2e1a-413c-90db-31c6c012e4fd.png)

The _sum_ (to prove that the distribution isn't actually 0):
![image](https://user-images.githubusercontent.com/757280/136576448-bdee0030-ac7c-40a4-8510-f47e832c9cca.png)

The _max_ after applying this PR (ignore the spurious 0s, that's an unrelated issue):
![image](https://user-images.githubusercontent.com/757280/136576562-813a8636-b46d-4d97-9165-7fbf47bb5182.png)
